### PR TITLE
Improve MainApplication modification for SDK 52+: Support Kotlin and …

### DIFF
--- a/build/withWatermelon.js
+++ b/build/withWatermelon.js
@@ -61,17 +61,50 @@ function buildGradle(config) {
 // https://github.com/morrowdigital/watermelondb-expo-plugin/pull/51/files#diff-ac4d678cfe00980f9ba9c66167516e4ab4139b78c94ff9c5083553ae8ad1f79e
 function mainApplicationSDK52(config) {
     return (0, config_plugins_1.withMainApplication)(config, (mod) => {
+        console.log("[WatermelonDB] Configuring MainApplication for SDK 52+");
+        // Add import if not present
         if (!mod.modResults.contents.includes("import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage")) {
-            mod.modResults["contents"] = mod.modResults.contents.replace("import android.app.Application", `
-import android.app.Application
+            console.log("[WatermelonDB] Adding WatermelonDBJSIPackage import");
+            mod.modResults.contents = mod.modResults.contents.replace("import android.app.Application", `import android.app.Application
 import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage;        
 `);
         }
-        if (!mod.modResults.contents.includes("packages.add(WatermelonDBJSIPackage())")) {
-            const newContents2 = mod.modResults.contents.replace("return packages", `
-            packages.add(WatermelonDBJSIPackage())
+        else {
+            console.log("[WatermelonDB] WatermelonDBJSIPackage import already exists");
+        }
+        // Add package registration if not present
+        if (!mod.modResults.contents.includes("add(WatermelonDBJSIPackage())")) {
+            console.log("[WatermelonDB] Adding WatermelonDBJSIPackage() to packages");
+            let patternMatched = false;
+            // Pattern 1: Kotlin with .apply {} block (SDK 52+)
+            // Matches: PackageList(this).packages.apply {
+            //            // comment
+            //            // add(MyReactNativePackage())
+            //          }
+            if (mod.modResults.contents.includes("PackageList(this).packages.apply")) {
+                console.log("[WatermelonDB] Detected Kotlin .apply pattern");
+                // Insert after the example comment line
+                mod.modResults.contents = mod.modResults.contents.replace(/(\/\/ add\(MyReactNativePackage\(\)\))/, `$1
+              add(WatermelonDBJSIPackage())`);
+                patternMatched = true;
+            }
+            // Pattern 2: Old Java pattern (fallback for older SDKs)
+            else if (mod.modResults.contents.includes("return packages")) {
+                console.log("[WatermelonDB] Detected Java return packages pattern");
+                mod.modResults.contents = mod.modResults.contents.replace("return packages", `packages.add(WatermelonDBJSIPackage())
         return packages`);
-            mod.modResults.contents = newContents2;
+                patternMatched = true;
+            }
+            if (patternMatched) {
+                console.log("[WatermelonDB] Successfully added WatermelonDBJSIPackage()");
+            }
+            else {
+                console.warn("[WatermelonDB] ⚠️  Could not find suitable pattern to inject WatermelonDBJSIPackage()");
+                console.warn("[WatermelonDB] Please manually add: add(WatermelonDBJSIPackage()) to your MainApplication file");
+            }
+        }
+        else {
+            console.log("[WatermelonDB] WatermelonDBJSIPackage() already registered");
         }
         return mod;
     });


### PR DESCRIPTION
…robust package injection

- Add console logs for import and package injection steps
- Support Kotlin PackageList(this).packages.apply pattern and inject add(WatermelonDBJSIPackage())
- Keep Java fallback for return packages and inject packages.add(WatermelonDBJSIPackage())
- Emit warnings when no suitable injection pattern is found
- Avoid duplicate imports/registrations by checking for existing entries